### PR TITLE
chore: drop pr concurrent limit of 10 for default of 20

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,8 +4,7 @@
   "extends": [
     "config:base",
     "npm:unpublishSafe",
-    ":onlyNpm",
-    ":prConcurrentLimit10"
+    ":onlyNpm"
   ],
   "labels": ["dependencies"],
   "rangeStrategy": "bump",


### PR DESCRIPTION
Drop PR concurrent limit of 10 for default of 20: https://docs.renovatebot.com/presets-config/#configbase