### PR TITLE
chore: exclude node engine upgrades

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,6 +7,12 @@
     ":onlyNpm"
   ],
   "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["node"],
+      "enabled": false
+    }
+  ],
   "prHourlyLimit": 10,
   "rangeStrategy": "bump",
   "schedule": [


### PR DESCRIPTION
Exclude node engine upgrades