### PR TITLE
fix: add not-pending prcreation config

### DIFF
--- a/default.json
+++ b/default.json
@@ -25,16 +25,17 @@
       "groupName": "rollup"
     },
     {
-      "matchPackagePatterns": ["@types", "typescript"],
-      "groupName": "typescript"
-    },
-    {
       "matchPackagePatterns": ["@testing-library"],
       "groupName": "@testing-library"
+    },
+    {
+      "matchPackagePatterns": ["@types", "typescript"],
+      "groupName": "typescript"
     }
   ],
   "prHourlyLimit": 10,
   "rangeStrategy": "bump",
+  "prCreation": "not-pending",
   "schedule": [
     "after 4:00 am on Friday on the 1st through 7th day of the month every 1 month"
   ],


### PR DESCRIPTION
add config so that when a version not passing stability days then the pr wont be created.