### PR TITLE
fix: override pr concurrent and hourly limits in config:base

### DIFF
--- a/default.json
+++ b/default.json
@@ -33,6 +33,8 @@
       "groupName": "typescript"
     }
   ],
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
   "rangeStrategy": "bump",
   "rollbackPrs": true,
   "schedule": [


### PR DESCRIPTION
`config:base` has differing default values compared to renovate defaults for concurrent and hourly PR limits