### PR TITLE
Revert "chore: enable vulnerability alerts"

### DIFF
--- a/default.json
+++ b/default.json
@@ -51,8 +51,5 @@
   "schedule": [
     "after 4:00 am on Friday on the 1st through 7th day of the month every 3 month"
   ],
-  "timezone": "Australia/Melbourne",
-  "vulnerabilityAlerts": {
-    "enabled": true
-  }
+  "timezone": "Australia/Melbourne"
 }


### PR DESCRIPTION
Reverts Adslot/renovate-config-adslot#17

`package.json` was not updated as expected, would continue to rely on dependabot alerts