### PR TITLE
chore: add npm version constraint

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,6 +1,9 @@
 {
   "additionalReviewers": ["bchew", "xiaofan2406"],
   "branchPrefix": "renovate-",
+  "constraints": {
+    "npm": "8.5.5"
+  },
   "extends": ["config:base", ":onlyNpm"],
   "labels": ["dependencies"],
   "packageRules": [


### PR DESCRIPTION
Add npm version constraint to 8.5.5 to maintain consistency across projects

Doc link: https://docs.renovatebot.com/configuration-options/#constraints