### PR TITLE
chore: disable vulnerability alerts in preference to dependabot

### DIFF
--- a/default.json
+++ b/default.json
@@ -54,5 +54,8 @@
   "schedule": [
     "after 4:00 am on Friday on the 1st through 7th day of the month every 3 month"
   ],
-  "timezone": "Australia/Melbourne"
+  "timezone": "Australia/Melbourne",
+  "vulnerabilityAlerts": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
Security PRs renovate creates do not update the `package.json` and only `package-lock.json`, so would rely on dependabot for that