### PR TITLE
chore: retest renovate vulnerability alerts

### DIFF
--- a/default.json
+++ b/default.json
@@ -56,6 +56,7 @@
   ],
   "timezone": "Australia/Melbourne",
   "vulnerabilityAlerts": {
-    "enabled": false
+    "enabled": true,
+    "rangeStrategy": "bump"
   }
 }


### PR DESCRIPTION
Override default `rangeStrategy` in `vulnerabilitAlerts` configuration object of `update-lockfile` to see if it resolves our previous issue with renovate as per https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts