### PR TITLE
[ADS-6817] chore: bump npm version to 8.11.0

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,7 @@
   "additionalReviewers": ["bchew", "xiaofan2406"],
   "branchPrefix": "renovate-",
   "constraints": {
-    "npm": "8.5.5"
+    "npm": "8.11.0"
   },
   "extends": ["config:base", ":onlyNpm"],
   "labels": ["dependencies"],


### PR DESCRIPTION
Bump npm version to 8.11.0 to match what is used in nodejs 16.15.1