### PR TITLE
chore: disable npm engine version updating

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,7 +8,7 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
-      "matchPackageNames": ["node"],
+      "matchPackageNames": ["node", "npm"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Disable npm engine version updating as we now want to ensure it's set to the explicit version used across projects