### PR TITLE
chore: remove no longer needed npm constraints

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,9 +1,6 @@
 {
   "additionalReviewers": ["bchew", "xiaofan2406"],
   "branchPrefix": "renovate-",
-  "constraints": {
-    "npm": "8.11.0"
-  },
   "extends": ["config:base", ":disableDigestUpdates", ":onlyNpm"],
   "labels": ["dependencies"],
   "packageRules": [


### PR DESCRIPTION
npm constraints no longer needed as we now specify the version we use in our node projects