### PR TITLE
chore: temp disable for next quarterly run

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,6 +1,7 @@
 {
   "additionalReviewers": ["bchew", "xiaofan2406"],
   "branchPrefix": "renovate-",
+  "enabled": false,
   "extends": ["config:base", ":disableDigestUpdates", ":onlyNpm"],
   "labels": ["dependencies"],
   "packageRules": [


### PR DESCRIPTION
Temp disable for next quarterly run as it has been brought forward https://docs.renovatebot.com/configuration-options/#enabled

To be reverted after next scheduled run.