### PR TITLE
chore: readd npm to constraints

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,6 +1,9 @@
 {
   "additionalReviewers": ["bchew", "xiaofan2406"],
   "branchPrefix": "renovate-",
+  "constraints": {
+    "npm": "9.3.1"
+  },
   "extends": ["config:base", ":disableDigestUpdates", ":onlyNpm"],
   "labels": ["dependencies"],
   "packageRules": [


### PR DESCRIPTION
Our OSS projects do not have npm version specified in package.jsons, so readding it back in