### PR TITLE
fix: fix deprecated onlyNpm default preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,7 +10,8 @@
   "extends": [
     "config:recommended",
     ":disableDigestUpdates",
-    ":onlyNpm",
+    ":docker",
+    ":npm",
     ":semanticCommits"
   ],
   "labels": [


### PR DESCRIPTION
Fix renovate configuration issues popping up across repos due to: https://github.com/renovatebot/renovate/pull/25644