### PR TITLE
chore: remove docker default preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,7 +10,6 @@
   "extends": [
     "config:recommended",
     ":disableDigestUpdates",
-    ":docker",
     ":npm",
     ":semanticCommits"
   ],


### PR DESCRIPTION
Unnecessary since renovate is not able to access our private ECR repos