### PR TITLE
chore: fix up package rules

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,18 @@
+name: renovate-config-validator
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.1.0
+        with:
+          config_file_path: |
+            default.json

--- a/default.json
+++ b/default.json
@@ -27,117 +27,105 @@
       "enabled": false
     },
     {
-      "matchPackagePatterns": [
+      "matchPackageNames": [
+        "@commitlint/**",
+        "chai",
+        "husky",
+        "lint-staged",
+        "mocha",
+        "nodemon",
+        "nyc",
+        "prettier",
+        "sinon",
+        "stylelint",
+        "supertest"
+      ],
+      "groupName": "devDeps"
+    },
+    {
+      "matchPackageNames": [
+        "@axe-core/**",
+        "@wdio/**",
+        "allure-commandline",
+        "axe-html-reporter",
+        "otpauth",
+        "webdriverio"
+      ],
+      "groupName": "e2e"
+    },
+    {
+      "matchPackageNames": [
+        "axios"
+      ],
+      "groupName": "axios"
+    },
+    {
+      "matchPackageNames": [
+        "draft-js",
+        "@draft-js/**"
+      ],
+      "groupName": "draft-js"
+    },
+    {
+      "matchPackageNames": [
         "eslint"
       ],
-      "groupName": "eslint",
-      "recreateClosed": false
+      "groupName": "eslint"
     },
     {
-      "matchPackagePatterns": [
-        "stylelint"
-      ],
-      "groupName": "stylelint",
-      "recreateClosed": false
-    },
-    {
-      "matchPackagePatterns": [
-        "redux"
-      ],
-      "groupName": "redux",
-      "recreateClosed": false
-    },
-    {
-      "matchPackagePatterns": [
-        "webpack"
-      ],
-      "groupName": "webpack",
-      "recreateClosed": false
-    },
-    {
-      "matchPackagePatterns": [
-        "rollup"
-      ],
-      "groupName": "rollup",
-      "recreateClosed": false
-    },
-    {
-      "matchPackagePatterns": [
-        "postcss"
-      ],
-      "groupName": "postcss",
-      "recreateClosed": false
-    },
-    {
-      "matchPackagePatterns": [
-        "classnames"
-      ],
-      "groupName": "classnames",
-      "recreateClosed": false
-    },
-    {
-      "matchPackagePatterns": [
-        "lodash"
-      ],
-      "groupName": "lodash",
-      "recreateClosed": false
-    },
-    {
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "jest"
       ],
-      "groupName": "jest",
-      "recreateClosed": false
+      "groupName": "jest"
     },
     {
-      "matchPackagePatterns": [
-        "draft-js"
+      "matchPackageNames": [
+        "moment"
       ],
-      "groupName": "draft-js",
-      "recreateClosed": false
+      "groupName": "moment"
     },
     {
-      "matchPackagePatterns": [
-        "react-datepicker"
-      ],
-      "groupName": "react-datepicker",
-      "recreateClosed": false
-    },
-    {
-      "matchPackagePatterns": [
-        "react-select"
-      ],
-      "groupName": "react-select",
-      "recreateClosed": false
-    },
-    {
-      "matchPackagePatterns": [
-        "react-slick"
-      ],
-      "groupName": "react-slick",
-      "recreateClosed": false
-    },
-    {
-      "matchPackagePatterns": [
-        "@testing-library"
-      ],
-      "groupName": "testing-library",
-      "recreateClosed": false
-    },
-    {
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "pino"
       ],
-      "groupName": "pino",
-      "recreateClosed": false
+      "groupName": "pino"
     },
     {
-      "matchPackagePatterns": [
-        "@types",
+      "matchPackageNames": [
+        "postcss"
+      ],
+      "groupName": "postcss"
+    },
+    {
+      "matchPackageNames": [
+        "redux"
+      ],
+      "groupName": "redux"
+    },
+    {
+      "matchPackageNames": [
+        "rollup"
+      ],
+      "groupName": "rollup"
+    },
+    {
+      "matchPackageNames": [
+        "@testing-library/**"
+      ],
+      "groupName": "testing-library"
+    },
+    {
+      "matchPackageNames": [
+        "@types/**",
         "typescript"
       ],
-      "groupName": "typescript",
-      "recreateClosed": false
+      "groupName": "typescript"
+    },
+    {
+      "matchPackageNames": [
+        "webpack"
+      ],
+      "groupName": "webpack"
     }
   ],
   "prConcurrentLimit": 0,


### PR DESCRIPTION
- Fix up package rules to use `matchPackageNames` as per https://docs.renovatebot.com/configuration-options/#matchpackagenames and glob matching as per https://docs.renovatebot.com/string-pattern-matching/
- Add renovate config validation GitHub Action: https://github.com/suzuki-shunsuke/github-action-renovate-config-validator