### PR TITLE
chore: temp disable for next quarterly run

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,6 +4,7 @@
     "xiaofan2406"
   ],
   "branchPrefix": "renovate-",
+  "enabled": false,
   "constraints": {
     "npm": "11.6.2"
   },


### PR DESCRIPTION
Temp disable for next quarterly run as it has been brought forward https://docs.renovatebot.com/configuration-options/#enabled

To be reverted after next scheduled run.